### PR TITLE
Remove unused import from tennis database script

### DIFF
--- a/AdvancedChallenges/TennisDatabase/main.py
+++ b/AdvancedChallenges/TennisDatabase/main.py
@@ -1,6 +1,5 @@
 #Libarys
 import sqlite3
-from secrets import token_urlsafe
 from time import sleep
 
 conn = sqlite3.connect("database.db")


### PR DESCRIPTION
## Summary
- remove unused `token_urlsafe` import from tennis database main program

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688fdc0299908320ae2473794dfe5f72